### PR TITLE
[Feature] Pass keyPath to comparators

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ The key path to the first node for which `comparator` returned `true`.
 
 Returns an [List](http://facebook.github.io/immutable-js/docs/#/List) of key paths pointing at the nodes for which `comparator` returned `true`.
 ```js
-treeUtils.filter(node => node.get('type') === 'folder');
+treeUtils.filter(state, node => node.get('type') === 'folder');
 //List [ Seq[], Seq["childNodes", 0], Seq["childNodes", 1] ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ function insert(state, newNode, parentId, index) {
 Install the package from [npm](https://www.npmjs.com/package/immutable-treeutils):
 
 ```
-npm install immutable-treeutils
+npm install immutable-tree
 ```
 
 **Note:** This library relies on *ES6 generators* so you need either an environment that supports them or to include some polyfill like [regenerator](https://github.com/facebook/regenerator) or [babel's polyfill](https://babeljs.io/docs/usage/polyfill/) before importing `immutable-treeutils`;
@@ -89,7 +89,7 @@ let treeUtils = new TreeUtils();
 let data = Immutable.fromJS({
 	id: 'root',
 	name: 'My Documents',
-	type: 'folder',
+	type: 'folder'
 	childNodes: [
 		{
 			id: 'node-1',
@@ -253,13 +253,16 @@ treeUtils.find(state, node => node.get('name') === 'Me in Paris');
 ```js
 find(
    state: Immutable.Iterable,
-   comparator: Function,
+   comparator: (
+        node: Immutable.Iterable, 
+        keyPath: Immutable.Seq<string|number>
+    ): boolean,
    path?: Immutable.Seq<string|number>
 ): Immutable.Seq<string|number>
 ```
 
 ###### Arguments:
-* `comparator` - A function that gets passed a node and should return whether it fits the criteria or not.
+* `comparator` - A function that gets passed a `node` and a `keyPath` and should return whether it fits the criteria or not.
 * `path?` - An optional key path to the (sub)state you want to analyse: Default: The `TreeUtils` object's `rootPath`.
 
 ###### Returns:
@@ -283,13 +286,16 @@ treeUtils.filter(node => node.get('type') === 'folder');
 ```js
 filter(
     state: Immutable.Iterable,
-    comparator: Function,
+    comparator: (
+        node: Immutable.Iterable, 
+        keyPath: Immutable.Seq<string|number>
+    ): boolean,
     path?: Immutable.Seq<string|number>
 ): List<Immutable.Seq<string|number>>
 ```
 
 ###### Arguments:
-* `comparator` - A function that gets passed a node and should return whether it fits the criteria or not.
+* `comparator` - A function that gets passed a `node` and a `keyPath` and should return whether it fits the criteria or not.
 * `path?` - An optional key path to the (sub)state you want to analyse: Default: The `TreeUtils` object's `rootPath`.
 
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ function insert(state, newNode, parentId, index) {
 Install the package from [npm](https://www.npmjs.com/package/immutable-treeutils):
 
 ```
-npm install immutable-tree
+npm install immutable-treeutils
 ```
 
 **Note:** This library relies on *ES6 generators* so you need either an environment that supports them or to include some polyfill like [regenerator](https://github.com/facebook/regenerator) or [babel's polyfill](https://babeljs.io/docs/usage/polyfill/) before importing `immutable-treeutils`;

--- a/lib/TreeUtils.js
+++ b/lib/TreeUtils.js
@@ -291,7 +291,7 @@ var TreeUtils = function () {
    *
    * Returns an >Immutable.List of key paths pointing at the nodes for which `comparator` returned `true`.
    * ```js
-   * treeUtils.filter(node => node.get('type') === 'folder');
+   * treeUtils.filter(state, node => node.get('type') === 'folder');
    * //List [ Seq[], Seq["childNodes", 0], Seq["childNodes", 1] ]
    * ```
    *

--- a/lib/TreeUtils.js
+++ b/lib/TreeUtils.js
@@ -237,13 +237,16 @@ var TreeUtils = function () {
    * ```js
    * find(
    *    state: Immutable.Iterable,
-   *    comparator: Function,
+   *    comparator: (
+   *         node: Immutable.Iterable, 
+   *         keyPath: Immutable.Seq<string|number>
+   *     ): boolean,
    *    path?: Immutable.Seq<string|number>
    * ): Immutable.Seq<string|number>
    * ```
    *
    * ###### Arguments:
-   * * `comparator` - A function that gets passed a node and should return whether it fits the criteria or not.
+   * * `comparator` - A function that gets passed a `node` and a `keyPath` and should return whether it fits the criteria or not.
    * * `path?` - An optional key path to the (sub)state you want to analyse: Default: The `TreeUtils` object's `rootPath`.
    *
    * ###### Returns:
@@ -261,7 +264,7 @@ var TreeUtils = function () {
 				for (var _iterator2 = this.nodes(state, path)[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
 					var keyPath = _step2.value;
 
-					if (comparator(state.getIn(keyPath)) === true) {
+					if (comparator(state.getIn(keyPath), keyPath) === true) {
 						return keyPath;
 					}
 				}
@@ -296,13 +299,16 @@ var TreeUtils = function () {
    * ```js
    * filter(
    *     state: Immutable.Iterable,
-   *     comparator: Function,
+   *     comparator: (
+   *         node: Immutable.Iterable, 
+   *         keyPath: Immutable.Seq<string|number>
+   *     ): boolean,
    *     path?: Immutable.Seq<string|number>
    * ): List<Immutable.Seq<string|number>>
    * ```
    *
    * ###### Arguments:
-   * * `comparator` - A function that gets passed a node and should return whether it fits the criteria or not.
+   * * `comparator` - A function that gets passed a `node` and a `keyPath` and should return whether it fits the criteria or not.
    * * `path?` - An optional key path to the (sub)state you want to analyse: Default: The `TreeUtils` object's `rootPath`.
    *
    *
@@ -322,7 +328,7 @@ var TreeUtils = function () {
 				for (var _iterator3 = this.nodes(state, path)[Symbol.iterator](), _step3; !(_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done); _iteratorNormalCompletion3 = true) {
 					var keyPath = _step3.value;
 
-					if (comparator(state.getIn(keyPath)) === true) {
+					if (comparator(state.getIn(keyPath), keyPath) === true) {
 						result = result.push(keyPath);
 					}
 				}

--- a/scripts/README.mustache
+++ b/scripts/README.mustache
@@ -73,7 +73,7 @@ function insert(state, newNode, parentId, index) {
 Install the package from [npm](https://www.npmjs.com/package/immutable-treeutils):
 
 ```
-npm install immutable-tree
+npm install immutable-treeutils
 ```
 
 **Note:** This library relies on *ES6 generators* so you need either an environment that supports them or to include some polyfill like [regenerator](https://github.com/facebook/regenerator) or [babel's polyfill](https://babeljs.io/docs/usage/polyfill/) before importing `immutable-treeutils`;

--- a/src/TreeUtils.js
+++ b/src/TreeUtils.js
@@ -175,7 +175,7 @@ export default class TreeUtils {
 	 *
 	 * Returns an >Immutable.List of key paths pointing at the nodes for which `comparator` returned `true`.
 	 * ```js
-	 * treeUtils.filter(node => node.get('type') === 'folder');
+	 * treeUtils.filter(state, node => node.get('type') === 'folder');
 	 * //List [ Seq[], Seq["childNodes", 0], Seq["childNodes", 1] ]
 	 * ```
 	 *

--- a/src/TreeUtils.js
+++ b/src/TreeUtils.js
@@ -145,13 +145,16 @@ export default class TreeUtils {
 	 * ```js
 	 * find(
 	 *    state: Immutable.Iterable,
-	 *    comparator: Function,
+	 *    comparator: (
+	 *         node: Immutable.Iterable, 
+	 *         keyPath: Immutable.Seq<string|number>
+	 *     ): boolean,
 	 *    path?: Immutable.Seq<string|number>
 	 * ): Immutable.Seq<string|number>
 	 * ```
 	 *
 	 * ###### Arguments:
-	 * * `comparator` - A function that gets passed a node and should return whether it fits the criteria or not.
+	 * * `comparator` - A function that gets passed a `node` and a `keyPath` and should return whether it fits the criteria or not.
 	 * * `path?` - An optional key path to the (sub)state you want to analyse: Default: The `TreeUtils` object's `rootPath`.
 	 *
 	 * ###### Returns:
@@ -159,7 +162,7 @@ export default class TreeUtils {
 	 */
 	find(state, comparator, path) {
 		for (let keyPath of this.nodes(state, path)) {
-			if (comparator(state.getIn(keyPath)) === true) {
+			if (comparator(state.getIn(keyPath), keyPath) === true) {
 				return keyPath;
 			}
 		}
@@ -180,13 +183,16 @@ export default class TreeUtils {
 	 * ```js
 	 * filter(
 	 *     state: Immutable.Iterable,
-	 *     comparator: Function,
+	 *     comparator: (
+	 *         node: Immutable.Iterable, 
+	 *         keyPath: Immutable.Seq<string|number>
+	 *     ): boolean,
 	 *     path?: Immutable.Seq<string|number>
 	 * ): List<Immutable.Seq<string|number>>
 	 * ```
 	 *
 	 * ###### Arguments:
-	 * * `comparator` - A function that gets passed a node and should return whether it fits the criteria or not.
+	 * * `comparator` - A function that gets passed a `node` and a `keyPath` and should return whether it fits the criteria or not.
 	 * * `path?` - An optional key path to the (sub)state you want to analyse: Default: The `TreeUtils` object's `rootPath`.
 	 *
 	 *
@@ -196,7 +202,7 @@ export default class TreeUtils {
 	filter(state, comparator, path) {
 		let result = List();
 		for (let keyPath of this.nodes(state, path)) {
-			if (comparator(state.getIn(keyPath)) === true) {
+			if (comparator(state.getIn(keyPath), keyPath) === true) {
 				result = result.push(keyPath);
 			}
 		}


### PR DESCRIPTION
Sometimes it would be useful to know the `keyPath` of a `node` inside of a `comparator` function. So I suggest to pass the `keyPath` to the `comparator` functions of `TreeUtils.find` and `TreeUtils.filter` in accordance to [`Array.prototype.find`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find) and [`Array.prototype.filter`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter).

**Usage Example**: Let's say you want to compare one tree to another according to certain properties. Then you can easily compare nodes by using `filter` if you also have the `keyPath` in the `comparator` function.