### PR TITLE
Add convenience module.exports for pre ES2015 environments

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,8 @@
 {
   "presets": [
     "es2015"
+  ],
+  "plugins": [
+    "add-module-exports"
   ]
 }

--- a/lib/TreeUtils.js
+++ b/lib/TreeUtils.js
@@ -1024,3 +1024,4 @@ var TreeUtils = function () {
 }();
 
 exports.default = TreeUtils;
+module.exports = exports['default'];

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "babel-cli": "^6.22.2",
     "babel-core": "^6.22.1",
     "babel-eslint": "^7.1.1",
+    "babel-plugin-add-module-exports": "^0.2.1",
     "babel-polyfill": "^6.22.0",
     "babel-preset-es2015": "^6.22.0",
     "eslint": "^3.14.0",


### PR DESCRIPTION
To use this library in a pre ES2015 environment you now have to do the following:
```javascript
var TreeUtils = require('immutable-treeutils').default;
```
This might not be obvious for most users and it is also quite inconvenient. With this pull request users can just do as expected:
```javascript
var TreeUtils = require('immutable-treeutils');
```