### PR TITLE
improve doc for nodes()

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ nodes(
 
 ###### Returns:
 
-An **unordered** [List](http://facebook.github.io/immutable-js/docs/#/List) of all key paths that point to nodes in the tree.
+An **unordered** [List](http://facebook.github.io/immutable-js/docs/#/List) of all key paths that point to nodes in the tree, including the root of the (sub)tree.
 
 ---
 


### PR DESCRIPTION
The current doc forgets to mention that the set of nodes returned from `nodes()` includes the root node.